### PR TITLE
Export core TypeScript types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@
  * See /fetch-polyfill for a version that works in environments that don't.
  */
 export { PineconeClient } from './pinecone-client';
+
+export type { Filter, Vector, QueryParams, QueryResults } from './types';


### PR DESCRIPTION
It's nicer to import these directly from the library intead of having to
pick them off of the PineconeClient class.
