### PR TITLE
Fixes typo in README code example.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ type Metadata = {};
 
 const pinecone = new PineconeClient<Metadata>({
   apiKey: '<your api key>',
-  baseUrl: '<your index url>'
+  baseUrl: '<your index url>',
   namespace: 'testing',
 });
 ```


### PR DESCRIPTION
Example code should run cleanly now.