### PR TITLE
Clone response before reading body in err hook

### DIFF
--- a/src/fetch-api.ts
+++ b/src/fetch-api.ts
@@ -16,7 +16,7 @@ export function createApiInstance(opts: { apiKey: string; baseUrl: string }) {
           const { response } = error;
           if (response && response.body) {
             try {
-              const body = await response.json();
+              const body = await response.clone().json();
               if (body.message) {
                 return new PineconeError(body.message, {
                   code: body.code,


### PR DESCRIPTION
The response should be cloned in the error hook before the body is read
to avoid a response already read error if the client error handling code
tries to read the response body again.

Context: https://github.com/sindresorhus/ky/issues/479
